### PR TITLE
added to header repo, version.  shortened

### DIFF
--- a/formToObject.js
+++ b/formToObject.js
@@ -1,27 +1,4 @@
-/*
-MIT License
-===========
-
-Copyright (c) 2013 Serban Ghita <serbanghita@gmail.com>
-
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the "Software"),
-to deal in the Software without restriction, including without limitation
-the rights to use, copy, modify, merge, publish, distribute, sublicense,
-and/or sell copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-*/
+/*! github.com/serbanghita/formToObject.js 1.0.1  (c) 2013 Serban Ghita <serbanghita@gmail.com> @licence MIT */
 
 (function(){
 


### PR DESCRIPTION
Do not need to add the entire MIT license; for those who are worried, they can find your project.  Saved a HTTP packet.

Made finding your project & version much easier ;)  Needed because you can't depend on your filename to stay; JS can be concocted, renamed in caching, etc.

Edit: I added the `!` to `/*!` & `@licence` because many minifiers (eg UglyJS) will keep that comment with those flags.  Otherwise, when minified, your header will be removed.
